### PR TITLE
Fix Server Crash When Dev Files Not Available

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import fs from 'fs';
 import { promisify } from 'util';
 import { connectionSetupTypePrompt } from './scripts/api/prompts/index.js';
 import { error } from './scripts/shared/console.js';
-import { nodemongoPaths, restoreToFirstTimer, runningChangeConnection, runningDevScript, runningRestoreConnection } from './scripts/api/helpers/helpers.js';
+import { nodemongoPaths, restoreToFirstTimer, runningChangeConnection, runningDevScript, runningRestoreConnection, runningAtlasServerConnection, runningLocalServerConnection, startAtlasServer, startLocalServer } from './scripts/api/helpers/helpers.js';
 
 let { templatePath } = nodemongoPaths();
 const { pathToCheck } = templatePath;
@@ -18,6 +18,8 @@ export const chooseNodeMongoApiDBServer = async () => {
     await access(pathToCheck, fs.constants.R_OK);
     if (runningDevScript || runningChangeConnection) connectionSetupTypePrompt();
     if (runningRestoreConnection) restoreToFirstTimer();
+    if (runningLocalServerConnection) startLocalServer();
+    if (runningAtlasServerConnection) startAtlasServer();
   } catch(err) {
     error(`\nPath or directory '${pathToCheck}' does not exist. Enter correct path as parameter/argument in the chooseNodeMongoApiDBServer() method\n`);
   }

--- a/scripts/api/helpers/helpers.js
+++ b/scripts/api/helpers/helpers.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+const { spawn } = require('child_process');
 import { error, success, warning } from '../../shared/console.js';
 import { changeUserSettings, copyTemplateFiles, deletePreviousTemplateFiles, npmRunPackageJsonScript } from '../../shared/helpers.js';
 import { user } from './user.js';
@@ -30,6 +31,8 @@ const npmLifeCycleEvent = process.env.npm_lifecycle_event;
 export const runningDevScript = npmLifeCycleEvent === 'dev';
 export const runningChangeConnection = npmLifeCycleEvent === 'dev:change';
 export const runningRestoreConnection = npmLifeCycleEvent === 'dev:restore';
+export const runningLocalServerConnection = npmLifeCycleEvent === 'dev:local';
+export const runningAtlasServerConnection = npmLifeCycleEvent === 'dev:atlas';
 
 export const setTemplateFileDirExt = () => {
   let dbServerFileNames, ext;
@@ -124,4 +127,28 @@ export const restoreToFirstTimer = async () => {
   } catch(err) {
     error(err);
   }
+}
+
+const startServer = (runner, serverFile, errorMessage) => {
+  if (fs.existsSync(serverFile)) {
+    const nodemon = spawn('nodemon', ['--exec', runner, serverFile]);
+    nodemon.stdout.pipe(process.stdout);
+    nodemon.stderr.pipe(process.stderr);
+  } else {
+    error(errorMessage);
+  }
+}
+
+export const startLocalServer = () => {
+  const runner = process.argv[process.argv.length - 2];
+  const serverFile = process.argv[process.argv.length - 1];
+  let errorMessage = `You can only run dev:local command when you are in local development mode. \nYou can switch to local dev mode using dev:change command`;
+  startServer(runner, serverFile, errorMessage);
+}
+
+export const startAtlasServer = () => {
+  const runner = process.argv[process.argv.length - 2];
+  const serverFile = process.argv[process.argv.length - 1];
+  let errorMessage = `You can only run dev:atlas command when you are in atlas development mode. \nYou can switch to atlas dev mode using dev:change command`;
+  startServer(runner, serverFile, errorMessage);
 }


### PR DESCRIPTION
**This pull request makes the following changes**
* Fixes code-collabo/node-mongo/issues/54

**General checklist**
- [x] File or folder now contains changes as specified in the issue I worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**
- [x] When user is still in atlas mode: User has been informed that they can only use or access the `dev:local` script command when they have switched to local connection setup type via the `npm:change` script command
- [x] When user is still in local mode: User has been informed that they can only use or access the `dev:atlas` script command when they have switched to ATLAS connection setup type via the `npm:change` script command
- [x] I certify that I ran my checklist

![image](https://github.com/code-collabo/node-mongo-api-boilerplate-templates/assets/42407804/e7f8c2ed-25fa-4d09-987a-975ca67dbe14)

Ping @code-collabo/node-mongo-api-boilerplate-templates
